### PR TITLE
月別レッスン請求一覧

### DIFF
--- a/onlineschool/admin.py
+++ b/onlineschool/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from .models import User, Lesson, LessonRecord
+from .models import User, Lesson, LessonRecord, Discount
 
 admin.site.register(User)
 admin.site.register(Lesson)
 admin.site.register(LessonRecord)
+admin.site.register(Discount)

--- a/onlineschool/form.py
+++ b/onlineschool/form.py
@@ -3,6 +3,8 @@ from django import forms
 from onlineschool.models import User
 from onlineschool.models import LessonRecord
 
+import datetime
+from dateutil.relativedelta import relativedelta
 
 class UserForm(forms.ModelForm):
     sex = forms.ChoiceField(choices=User.SEX_CHOICES, label='性別')
@@ -16,8 +18,11 @@ class UserForm(forms.ModelForm):
             'age': '年齢'
         }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def clean_age(self):
+        age = self.cleaned_data['age']
+        if 0 > age or age > 120:
+            raise forms.ValidationError("年齢は0-120歳の間で設定をお願い致します")
+        return age
 
 
 class LessonRecordForm(forms.ModelForm):
@@ -31,3 +36,24 @@ class LessonRecordForm(forms.ModelForm):
             'lesson_date': '受講日',
             'lesson_hour': '受講時間(h)',
         }
+
+    def clean_lesson_hour(self):
+        lesson_hour = self.cleaned_data['lesson_hour']
+        if 0 > lesson_hour or lesson_hour > 12:
+            raise forms.ValidationError("レッスン時間は1-12時間の間で設定をお願い致します")
+        return lesson_hour
+
+
+class InvoiceSearchForm(forms.Form):
+
+    Month_CHOICES = (
+        (datetime.date.today().month, datetime.date.today().strftime('%m月')),
+        ((datetime.date.today()-relativedelta(months=1)).month, (datetime.date.today()-relativedelta(months=1)).strftime('%m月')),
+        ((datetime.date.today()-relativedelta(months=2)).month, (datetime.date.today()-relativedelta(months=2)).strftime('%m月')),
+    )
+
+    invoice_search = forms.ChoiceField(
+        label="請求書月別検索",
+        choices=Month_CHOICES
+    )
+

--- a/onlineschool/models.py
+++ b/onlineschool/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils import timezone
+from django import forms
 
 
 class User(models.Model):
@@ -26,6 +27,7 @@ class Lesson(models.Model):
     name = models.CharField(verbose_name='名前', max_length=255)
     basic_charge = models.IntegerField(verbose_name='基本料金')
     pay_per_charge = models.IntegerField(verbose_name='従量料金')
+    free_time = models.IntegerField(default=0, verbose_name='無料時間')
 
     def __str__(self):
         return self.name
@@ -39,3 +41,26 @@ class LessonRecord(models.Model):
     lesson_name = models.ForeignKey(Lesson, verbose_name='ジャンル名', on_delete=models.CASCADE)
     lesson_date = models.DateField(default=timezone.now, verbose_name='受講日')
     lesson_hour = models.IntegerField(verbose_name='受講時間')
+    lesson_charge = models.IntegerField(default=0, verbose_name='受講料金')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cleaned_lesson_hour = None
+
+    def clean_lesson_hour(self):
+        lesson_hour = self.cleaned_lesson_hour['lesson_hour']
+        if 0 >= lesson_hour > 12:
+            raise forms.ValidationError(
+                '0-12時間の間で入力してください'
+            )
+        return lesson_hour
+
+
+class Discount(models.Model):
+    class Meta:
+        db_table = 'discount'
+
+    lesson_name = models.ForeignKey(Lesson, verbose_name='ジャンル名', on_delete=models.CASCADE)
+    limited_hour = models.IntegerField(verbose_name='閾時間')
+    discount_price = models.IntegerField(verbose_name='割引額')
+

--- a/onlineschool/templates/onlineschool/index.html
+++ b/onlineschool/templates/onlineschool/index.html
@@ -4,7 +4,7 @@
 <ul>
     <li><a href="{% url 'onlineschool:user_list' %}">顧客一覧</a></li>
     <li><a href="{% url 'onlineschool:lesson_list' %}">レッスン受講記録</a></li>
-    <li><a href="#">月別請求一覧</a></li>
+    <li><a href="{% url 'onlineschool:lesson_invoice' %}">月別請求一覧</a></li>
     <li><a href="#">レポート</a></li>
 </ul>
 {% endblock %}

--- a/onlineschool/templates/onlineschool/lesson_invoice.html
+++ b/onlineschool/templates/onlineschool/lesson_invoice.html
@@ -1,0 +1,48 @@
+{% extends "onlineschool/base.html" %}
+{% load extras %}
+{% block body %}
+<h1>{{title}}</h1>
+<form action= "{% url 'onlineschool:lesson_invoice' %}" method = "post">
+    {% for field in form %}
+    <div class="field">
+        <div class="ui input">
+            {{ field.label_tag}}
+            {% csrf_token %}
+            {{field}}
+        </div>
+        {% if field.errors%}
+        <p class="red message">
+            {{ field.errors.0 }}
+        </p> {% endif%}
+    </div>
+    {% endfor%}
+    <input type="submit" value="検索">
+</form>
+<div class="table-responsive">
+  <table class="table table-hover table-condensed table-bordered table-striped">
+    <thead>
+    <tr>
+      <th>顧客ID</th>
+      <th>顧客名</th>
+      <th>ジャンル</th>
+      <th>合計レッスン数</th>
+      <th>請求金額</th>
+    </tr>
+    </thead>
+    <tbody>
+      {% for user in users %}
+    <tr>
+      <td>{{ user.id }}</td>
+      <td>{{ user.name }}</td>
+      <td>{{ lesson_search_month|month_lesson_genre:user }}</td>
+      <td>{{ lesson_search_month|month_lesson_count:user }}レッスン</td>
+      <td>{{ lesson_search_month|month_lesson_charge:user }}</td>
+    </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<a href="{% url 'onlineschool:index' %}"><button class="add-button">トップに戻る</button></a>
+
+{% endblock %}

--- a/onlineschool/templatetags/extras.py
+++ b/onlineschool/templatetags/extras.py
@@ -1,4 +1,7 @@
 from django import template
+from django.db.models import Sum, Count
+
+from onlineschool.models import LessonRecord, Discount
 
 register = template.Library()
 
@@ -7,3 +10,121 @@ register = template.Library()
 def mlti(value1, value2):
     total = value1 * value2
     return total
+
+
+@register.filter(name='total_lesson_hour')
+def total_lesson_hour(lesson_pay, lesson):
+    # 現在の合計受講時間をユーザー・レッスン・月別に集計
+    total_lesson_hour = LessonRecord.objects.all().filter(
+        lesson_name=lesson.lesson_name,
+        user_name=lesson.user_name,
+        lesson_date__month=lesson.lesson_date.month,
+        id__lte=lesson.id
+    ).aggregate(Sum('lesson_hour'))
+
+    # 前回までの合計受講時間をユーザー・レッスン・月別に集計
+    previous_total_lesson_hour = LessonRecord.objects.all().filter(
+        lesson_name=lesson.lesson_name,
+        user_name=lesson.user_name,
+        lesson_date__month=lesson.lesson_date.month,
+        id__lt=lesson.id
+    ).aggregate(Sum('lesson_hour'))
+
+    discount_rate = Discount.objects.order_by('-limited_hour').filter(lesson_name_id=lesson.lesson_name.id)
+    discount_rate_list = list(discount_rate)
+    discount_level_count = 0
+
+    # もし割引がない時、従量基本料金で計算
+    if not discount_rate_list:
+        return total_lesson_hour['lesson_hour__sum'] * lesson_pay
+
+    # もし割引がある時、従量基本料金にいくら割引するか計算
+    for discount_info in discount_rate:
+        # 合計受講時間が閾値以上あるとき
+        if total_lesson_hour['lesson_hour__sum'] >= discount_info.limited_hour:
+            final_lesson_charge = 0
+            deff_from_limited = total_lesson_hour['lesson_hour__sum'] - discount_rate_list[0].limited_hour
+
+            if len(discount_rate) - 1 != discount_level_count:
+                lesson_pay = discount_rate[discount_level_count + 1].discount_price
+
+            # 受講時間が閾値をまたいでいない時
+            if lesson.lesson_hour - deff_from_limited < 0:
+                final_lesson_charge = lesson.lesson_hour * discount_rate_list[0].discount_price
+            # 受講時間が閾値をまたいでいる時
+            else:
+                # 閾値を超えた分は割引額で計算
+                final_lesson_charge += deff_from_limited * discount_rate_list[0].discount_price
+                # 閾値以下分は割引前の額で計算
+                final_lesson_charge += (lesson.lesson_hour - deff_from_limited) * lesson_pay
+            return final_lesson_charge
+
+        # 合計受講時間が閾値以下の時
+        else:
+            if len(discount_rate_list) == 1:
+                # 合計受講時間が最小割引閾値を超えない時
+                if total_lesson_hour['lesson_hour__sum'] <= lesson.lesson_name.free_time:
+                    return 0
+                elif previous_total_lesson_hour[
+                        'lesson_hour__sum'] is not None:
+                    if previous_total_lesson_hour[
+                        'lesson_hour__sum'] < lesson.lesson_name.free_time and lesson.lesson_hour > lesson.lesson_name.free_time:
+                        return (lesson.lesson_hour - (lesson.lesson_name.free_time - previous_total_lesson_hour['lesson_hour__sum'])) * lesson_pay
+                elif total_lesson_hour['lesson_hour__sum'] > lesson.lesson_name.free_time and lesson.lesson_hour > lesson.lesson_name.free_time:
+                    return (lesson.lesson_hour - lesson.lesson_name.free_time) * lesson_pay
+                else:
+                    return total_lesson_hour['lesson_hour__sum'] * lesson_pay
+            else:
+                # 閾値の最大値を削除
+                discount_rate_list.pop(0)
+                discount_level_count += 1
+
+
+@register.filter(name='month_lesson_genre')
+def month_lesson_genre(month, user):
+    month_lesson_genre = LessonRecord.objects.all().filter(
+        user_name=user.id,
+        lesson_date__month=month,
+    )
+
+    genre_list = []
+    for lesson_genre in month_lesson_genre:
+        genre_list.append(lesson_genre.lesson_name.name)
+
+    return '{0} ({1})'.format(' / '.join(list(set(genre_list))), str(len(list(set(genre_list)))))
+
+
+@register.filter(name='month_lesson_count')
+def month_lesson_count(month, user):
+    month_lesson_count = LessonRecord.objects.all().filter(
+        user_name=user.id,
+        lesson_date__month=month,
+    ).aggregate(Count('id'))
+    return month_lesson_count['id__count']
+
+
+@register.filter(name='month_lesson_charge')
+def month_lesson_charge(month, user):
+    month_lesson_charge = LessonRecord.objects.all().filter(
+        user_name=user.id,
+        lesson_date__month=month,
+    ).aggregate(Sum('lesson_charge'))
+
+    month_lesson_genre = LessonRecord.objects.all().filter(
+        user_name=user.id,
+        lesson_date__month=month,
+    )
+
+    if month_lesson_charge['lesson_charge__sum'] is None:
+        total_basic_charge = 0
+    else:
+        total_basic_charge = month_lesson_charge['lesson_charge__sum']
+        if month_lesson_genre.exists():
+            genre_list = []
+            for lesson_genre in month_lesson_genre:
+                if str(lesson_genre.lesson_name) not in genre_list:
+                    total_basic_charge += lesson_genre.lesson_name.basic_charge
+                genre_list.append(str(lesson_genre.lesson_name))
+
+    return total_basic_charge
+

--- a/onlineschool/urls.py
+++ b/onlineschool/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path('lesson_form', views.lesson_form, name='lesson_form'),
     path('lesson_form/<int:lesson_id>/', views.lesson_edit, name='lesson_edit'),
     path('lesson_delete/<int:lesson_id>/', views.lesson_delete, name='lesson_delete'),
+    path('lesson_invoice', views.lesson_invoice, name='lesson_invoice'),
 ]

--- a/onlineschool/views.py
+++ b/onlineschool/views.py
@@ -1,11 +1,13 @@
+from django.db.models import Sum
 from django.shortcuts import (
     render,
     get_object_or_404,
 )
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from .models import User, LessonRecord
-from .form import UserForm, LessonRecordForm
+from .models import User, LessonRecord, Discount
+from .form import UserForm, LessonRecordForm, InvoiceSearchForm
+import datetime
 
 
 def index(request):
@@ -30,6 +32,12 @@ def user_form(request):
         if form.is_valid():
             form.save()
             return HttpResponseRedirect(reverse('onlineschool:user_list'))
+        else:
+            params = {
+                'title': '顧客登録',
+                'form': form
+            }
+            return render(request, 'onlineschool/user_new.html', params)
     else:
         params = {
             'title': '顧客登録',
@@ -77,8 +85,16 @@ def lesson_form(request):
     if request.method == 'POST':
         form = LessonRecordForm(request.POST)
         if form.is_valid():
-            form.save()
+            lesson = form.save()
+            lesson_with_charge = LessonRecord.objects.get(pk=lesson.id)
+            if total_lesson_hour(lesson_with_charge.lesson_name.pay_per_charge, lesson_with_charge) is None:
+                lesson_with_charge.lesson_charge = 0
+            else:
+                lesson_with_charge.lesson_charge = total_lesson_hour(lesson_with_charge.lesson_name.pay_per_charge, lesson_with_charge)
+            lesson_with_charge.save()
             return HttpResponseRedirect(reverse('onlineschool:lesson_list'))
+        else:
+            return render(request, 'onlineschool/lesson_new.html', {'form': form})
     else:
         params = {
             'title': 'レッスン登録',
@@ -93,11 +109,14 @@ def lesson_edit(request, lesson_id):
         form = LessonRecordForm(request.POST, instance=lesson)
         if form.is_valid():
             lesson.save()
+            lesson_with_charge = LessonRecord.objects.get(pk=lesson.id)
+            lesson_with_charge.lesson_charge = total_lesson_hour(lesson_with_charge.lesson_name.pay_per_charge, lesson_with_charge)
+            lesson_with_charge.save()
             return HttpResponseRedirect(reverse('onlineschool:lesson_list'))
     else:
         form = LessonRecordForm({
-            'user_name': lesson.user_name,
-            'lesson_name': lesson.lesson_name,
+            'user_name': lesson.user_name.id,
+            'lesson_name': lesson.lesson_name.id,
             'lesson_date': lesson.lesson_date,
             'lesson_hour': lesson.lesson_hour,
         })
@@ -117,3 +136,89 @@ def lesson_delete(request, lesson_id):
         'lessonrecords': LessonRecord.objects.all(),
     }
     return render(request, 'onlineschool/lesson_list.html', params)
+
+
+def lesson_invoice(request):
+    if request.method == 'POST':
+        params = {
+            'title': request.POST['invoice_search'] + '月レッスン請求一覧',
+            'users': User.objects.all(),
+            'form': InvoiceSearchForm(),
+            'lesson_search_month': request.POST['invoice_search']
+        }
+        return render(request, 'onlineschool/lesson_invoice.html', params)
+    else:
+        params = {
+            'title': 'レッスン請求一覧',
+            'users': User.objects.all(),
+            'form': InvoiceSearchForm(),
+            'lesson_search_month': datetime.date.today().month
+        }
+        return render(request, 'onlineschool/lesson_invoice.html', params)
+
+
+def total_lesson_hour(lesson_pay, lesson):
+    # 現在の合計受講時間をユーザー・レッスン・月別に集計
+    total_lesson_hour = LessonRecord.objects.all().filter(
+        lesson_name=lesson.lesson_name,
+        user_name=lesson.user_name,
+        lesson_date__month=lesson.lesson_date.month,
+        id__lte=lesson.id
+    ).aggregate(Sum('lesson_hour'))
+
+    # 前回までの合計受講時間をユーザー・レッスン・月別に集計
+    previous_total_lesson_hour = LessonRecord.objects.all().filter(
+        lesson_name=lesson.lesson_name,
+        user_name=lesson.user_name,
+        lesson_date__month=lesson.lesson_date.month,
+        id__lt=lesson.id
+    ).aggregate(Sum('lesson_hour'))
+
+    discount_rate = Discount.objects.order_by('-limited_hour').filter(lesson_name_id=lesson.lesson_name.id)
+    discount_rate_list = list(discount_rate)
+    discount_level_count = 0
+
+    # もし割引がない時、従量基本料金で計算
+    if not discount_rate_list:
+        return total_lesson_hour['lesson_hour__sum'] * lesson_pay
+
+    # もし割引がある時、従量基本料金にいくら割引するか計算
+    for discount_info in discount_rate:
+        # 合計受講時間が閾値以上あるとき
+        if total_lesson_hour['lesson_hour__sum'] >= discount_info.limited_hour:
+            final_lesson_charge = 0
+            deff_from_limited = total_lesson_hour['lesson_hour__sum'] - discount_rate_list[0].limited_hour
+
+            if len(discount_rate) - 1 != discount_level_count:
+                lesson_pay = discount_rate[discount_level_count + 1].discount_price
+
+            # 受講時間が閾値をまたいでいない時
+            if lesson.lesson_hour - deff_from_limited < 0:
+                final_lesson_charge = lesson.lesson_hour * discount_rate_list[0].discount_price
+            # 受講時間が閾値をまたいでいる時
+            else:
+                # 閾値を超えた分は割引額で計算
+                final_lesson_charge += deff_from_limited * discount_rate_list[0].discount_price
+                # 閾値以下分は割引前の額で計算
+                final_lesson_charge += (lesson.lesson_hour - deff_from_limited) * lesson_pay
+            return final_lesson_charge
+
+        # 合計受講時間が閾値以下の時
+        else:
+            # 合計受講時間が最小割引閾値を超えない時
+            if len(discount_rate_list) == 1:
+                # 合計受講時間が無料時間より少ないとき
+                if total_lesson_hour['lesson_hour__sum'] <= lesson.lesson_name.free_time:
+                    return 0
+                else:
+                    if previous_total_lesson_hour['lesson_hour__sum'] is not None:
+                        if previous_total_lesson_hour['lesson_hour__sum'] < lesson.lesson_name.free_time and total_lesson_hour['lesson_hour__sum'] > lesson.lesson_name.free_time:
+                            return (lesson.lesson_hour - (lesson.lesson_name.free_time - previous_total_lesson_hour['lesson_hour__sum'])) * lesson_pay
+                        else:
+                            return lesson.lesson_hour * lesson_pay
+                    else:
+                        return (lesson.lesson_hour - lesson.lesson_name.free_time) * lesson_pay
+            else:
+                # 閾値の最大値を削除
+                discount_rate_list.pop(0)
+                discount_level_count += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary
 gunicorn
 django-heroku
 whitenoise==3.3.1
+python-dateutil


### PR DESCRIPTION
## 概要
- 近々3ヶ月の月別請求を確認できる
- どのジャンルを受講したか・レッスン数も同時に確認できる

## 理由
月別の請求を表示できることにより、ユーザー利便性の向上を目指す