### PR TITLE
月別レポート一覧

### DIFF
--- a/onlineschool/templates/onlineschool/index.html
+++ b/onlineschool/templates/onlineschool/index.html
@@ -5,6 +5,6 @@
     <li><a href="{% url 'onlineschool:user_list' %}">顧客一覧</a></li>
     <li><a href="{% url 'onlineschool:lesson_list' %}">レッスン受講記録</a></li>
     <li><a href="{% url 'onlineschool:lesson_invoice' %}">月別請求一覧</a></li>
-    <li><a href="#">レポート</a></li>
+    <li><a href="{% url 'onlineschool:lesson_report' %}">レポート</a></li>
 </ul>
 {% endblock %}

--- a/onlineschool/templates/onlineschool/lesson_invoice.html
+++ b/onlineschool/templates/onlineschool/lesson_invoice.html
@@ -16,7 +16,7 @@
         </p> {% endif%}
     </div>
     {% endfor%}
-    <input type="submit" value="検索">
+    <input type="submit" value="検索" class="btn btn-primary mb-1">
 </form>
 <div class="table-responsive">
   <table class="table table-hover table-condensed table-bordered table-striped">
@@ -42,7 +42,7 @@
     </tbody>
   </table>
 </div>
-
-<a href="{% url 'onlineschool:index' %}"><button class="add-button">トップに戻る</button></a>
-
+<div class="text-center">
+<a href="{% url 'onlineschool:index' %}" class="btn btn-primary mb-1">トップに戻る</a>
+</div>
 {% endblock %}

--- a/onlineschool/templates/onlineschool/lesson_list.html
+++ b/onlineschool/templates/onlineschool/lesson_list.html
@@ -13,7 +13,6 @@
       <th>受講時間</th>
       <th>支払い金額</th>
       <th></th>
-      <th></th>
     </tr>
     </thead>
     <tbody>
@@ -26,16 +25,16 @@
       <td>{{ lesson.lesson_hour }}</td>
       <td>{{ lesson.lesson_charge }}</td>
       <td>
-        <a href="{% url 'onlineschool:lesson_edit' lesson_id=lesson.id %}">編集</a>
-        <a href="{% url 'onlineschool:lesson_delete' lesson_id=lesson.id %}">削除</a>
+        <a href="{% url 'onlineschool:lesson_edit' lesson_id=lesson.id %}" class="btn btn-primary mb-1">編集</a>
+        <a href="{% url 'onlineschool:lesson_delete' lesson_id=lesson.id %}" class="btn btn-primary mb-1">削除</a>
       </td>
-      <td>{{lesson.lesson_name.pay_per_charge|total_lesson_hour:lesson }}</td>
     </tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
-
-<a href="{% url 'onlineschool:index' %}"><button class="add-button">トップに戻る</button></a>
-<a href="{% url 'onlineschool:lesson_form' %}"><button class="add-button">新規追加</button></a>
+<div class="text-center">
+<a href="{% url 'onlineschool:index' %}" class="btn btn-primary mb-1">トップに戻る</a>
+<a href="{% url 'onlineschool:lesson_form' %}" class="btn btn-primary mb-1">新規追加</a>
+</div>
 {% endblock %}

--- a/onlineschool/templates/onlineschool/lesson_new.html
+++ b/onlineschool/templates/onlineschool/lesson_new.html
@@ -16,7 +16,7 @@
         </p> {% endif%}
     </div>
     {% endfor%}
-    <input type="submit" value="登録">
+    <input type="submit" value="登録" class="btn btn-primary mb-2">
 </form>
 {% if form.non_field_errors%}
 <div class="ui red message">

--- a/onlineschool/templates/onlineschool/lesson_report.html
+++ b/onlineschool/templates/onlineschool/lesson_report.html
@@ -1,0 +1,78 @@
+{% extends "onlineschool/base.html" %}
+{% load extras %}
+{% block body %}
+<h1>{{title}}</h1>
+<form action= "{% url 'onlineschool:lesson_report' %}" method = "post">
+    {% for field in form %}
+    <div class="field">
+        <div class="ui input">
+            {{ field.label_tag }}
+            {% csrf_token %}
+            {{field}}
+        </div>
+        {% if field.errors %}
+        <p class="red message">
+            {{ field.errors.0 }}
+        </p> {% endif %}
+    </div>
+    {% endfor%}
+    <input type="submit" value="検索" class="btn btn-primary mb-2">
+</form>
+
+<h2>ジャンルと性別別</h2>
+<div class="table-responsive">
+  <table class="table table-hover table-condensed table-bordered table-striped">
+    <thead>
+    <tr>
+      <th>ジャンル</th>
+      <th>性別</th>
+      <th>レッスン数</th>
+      <th>受講者数</th>
+      <th>売り上げ</th>
+    </tr>
+    </thead>
+    <tbody>
+      {% for ele_genre_sex in summarize_genre_sex %}
+    <tr>
+      <td>{{ ele_genre_sex.0 }}</td>
+      <td>{{ ele_genre_sex.1 }}</td>
+      <td>{{ lesson_search_month|month_lesson_count_genre_sex:ele_genre_sex }}レッスン</td>
+      <td>{{ lesson_search_month|month_user_count_genre_sex:ele_genre_sex }}人</td>
+      <td>{{ lesson_search_month|month_lesson_charge_genre_sex:ele_genre_sex }}</td>
+    </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<h2>ジャンルと年齢層別</h2>
+<div class="table-responsive">
+  <table class="table table-hover table-condensed table-bordered table-striped">
+    <thead>
+    <tr>
+      <th>ジャンル</th>
+      <th>性別</th>
+      <th>年齢層</th>
+      <th>レッスン数</th>
+      <th>受講者数</th>
+      <th>売り上げ</th>
+    </tr>
+    </thead>
+    <tbody>
+      {% for ele_genre_sex_age in summarize_genre_sex_age %}
+    <tr>
+      <td>{{ ele_genre_sex_age.0 }}</td>
+      <td>{{ ele_genre_sex_age.1 }}</td>
+      <td>{{ ele_genre_sex_age.2 }}代</td>
+      <td>{{ lesson_search_month|month_lesson_count_genre_sex_age:ele_genre_sex_age }}レッスン</td>
+      <td>{{ lesson_search_month|month_user_count_genre_sex_age:ele_genre_sex_age }}人</td>
+      <td>{{ lesson_search_month|month_lesson_charge_genre_sex_age:ele_genre_sex_age }}</td>
+    </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<div class="text-center">
+<a href="{% url 'onlineschool:index' %}" class="btn btn-primary mb-1">トップに戻る</a>
+</div>
+{% endblock %}

--- a/onlineschool/templates/onlineschool/user_list.html
+++ b/onlineschool/templates/onlineschool/user_list.html
@@ -20,15 +20,16 @@
       <td>{{ user.sex }}</td>
       <td>{{ user.age }}</td>
       <td>
-        <a href="{% url 'onlineschool:user_edit' user_id=user.id %}">編集</a>
-        <a href="{% url 'onlineschool:user_delete' user_id=user.id %}">削除</a>
+        <a href="{% url 'onlineschool:user_edit' user_id=user.id %}" class="btn btn-primary mb-1">編集</a>
+        <a href="{% url 'onlineschool:user_delete' user_id=user.id %}" class="btn btn-primary mb-1">削除</a>
       </td>
     </tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
-
-<a href="{% url 'onlineschool:index' %}"><button class="add-button">トップに戻る</button></a>
-<a href="{% url 'onlineschool:user_form' %}"><button class="add-button">新規追加</button></a>
+<div class="text-center">
+  <a href="{% url 'onlineschool:index' %}" class="btn btn-primary mb-1">トップに戻る</a>
+  <a href="{% url 'onlineschool:user_form' %}" class="btn btn-primary mb-1">新規追加</a>
+</div>
 {% endblock %}

--- a/onlineschool/templates/onlineschool/user_new.html
+++ b/onlineschool/templates/onlineschool/user_new.html
@@ -3,7 +3,7 @@
 <h1>{{title}}</h1>
 
 <form action= "{% url 'onlineschool:user_form' %}" method = "post">
-    {% for field in form%}
+    {% for field in form %}
     <div class="field">
         <div class="ui input">
             {{ field.label_tag}}
@@ -13,12 +13,12 @@
         {% if field.errors%}
         <p class="red message">
             {{ field.errors.0 }}
-        </p> {% endif%}
+        </p> {% endif %}
     </div>
-    {% endfor%}
-    <input type="submit" value="登録">
+    {% endfor %}
+    <input type="submit" value="登録" class="btn btn-primary mb-2">
 </form>
-{% if form.non_field_errors%}
+{% if form.non_field_errors %}
 <div class="ui red message">
     <ul class="list">
         {% for non_field_error in form.non_field_errors%}

--- a/onlineschool/urls.py
+++ b/onlineschool/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     path('lesson_form/<int:lesson_id>/', views.lesson_edit, name='lesson_edit'),
     path('lesson_delete/<int:lesson_id>/', views.lesson_delete, name='lesson_delete'),
     path('lesson_invoice', views.lesson_invoice, name='lesson_invoice'),
+    path('lesson_report', views.lesson_report, name='lesson_report'),
 ]


### PR DESCRIPTION
## 概要
- 近々3ヶ月の月別レポートを確認できる
- ジャンル・性別別のレポーティングを生成
- ジャンル・性別別・年齢別のレポーティングを生成

## 理由
月別のレポートを表示できることにより、
ユーザー管理の向上を目指す